### PR TITLE
Reduce frame tail to 2 bytes

### DIFF
--- a/src/nmi/ed2ntc.asm
+++ b/src/nmi/ed2ntc.asm
@@ -5,7 +5,7 @@ EMU_UNKNOWN :=  $40
 FIFO_IDLE :=    $C1
 CMD_SEND_STATS := $42
 
-PAYLOAD_SIZE = $f1
+PAYLOAD_SIZE = $ed
 
 
 messageHeader:
@@ -219,10 +219,6 @@ sendNTCData:
 
 @addFooter:
         lda     #$AA
-        sta     FIFO_DATA
-        sta     FIFO_DATA
-        sta     FIFO_DATA
-        sta     FIFO_DATA
         sta     FIFO_DATA
         sta     FIFO_DATA
         lda     #$00


### PR DESCRIPTION
Ensures the frame size is below 240 bytes, so we can legitimately hope to get 60 fps:
```
115200/60/8 = 240
```
Tail was 6 bytes previously for total payload of 241 bytes, dropping 4 bytes brings the payload to 237 bytes.

Same change was made to NTC:
https://github.com/timotheeg/nestrischamps/pull/159/commits/30cba01eb3bd587008adec23bc1af53441f39752